### PR TITLE
Add GLPI Users

### DIFF
--- a/inc/info.class.php
+++ b/inc/info.class.php
@@ -539,7 +539,9 @@ class PluginPositionsInfo extends CommonDBTM {
                                'glpi_phonemodels',
                                'glpi_phonetypes',
                                'glpi_printermodels',
-                               'glpi_printertypes'];
+                               'glpi_printertypes',
+                               'glpi_usercategories',
+                               'glpi_usertitles'];
 
       if (in_array($searchOption['table'], $dropdown_tables)) {
          return "dropdown";

--- a/inc/info.class.php
+++ b/inc/info.class.php
@@ -569,7 +569,7 @@ class PluginPositionsInfo extends CommonDBTM {
          echo Html::formatNumber($display, 2);
 
       } else if ($searchOption['table'] == 'glpi_users') {
-         echo getUserName($display);
+         echo $display;
 
       } else if ($searchOption['field'] == 'contact_num') {
 

--- a/inc/position.class.php
+++ b/inc/position.class.php
@@ -44,7 +44,8 @@ class PluginPositionsPosition extends CommonDBTM {
                           'Printer',
                           'Phone',
                           'Location',
-                          'Netpoint'
+                          'Netpoint',
+                          'User'
    ];
 
    /**

--- a/setup.php
+++ b/setup.php
@@ -87,7 +87,7 @@ function plugin_version_positions() {
 
    return [
       'name'           => _n('Cartography', 'Cartographies', 1, 'positions'),
-      'version'        => '4.4.0',
+      'version'        => '4.4.1',
       'license'        => 'GPLv2+',
       'author'         => "<a href='http://infotel.com/services/expertise-technique/glpi/'>Infotel</a>",
       'homepage'       => 'https://github.com/InfotelGLPI/positions',


### PR DESCRIPTION
#32 
I know that there is a plugin called "resources" but as this has no automatic sync for the users (you have to create for every GLPI user an resources entry to be able to set the position). This is very complicated and often not required/wished/maintained. 

Give the users the possibility to decide to use GLPI User or "resources" plugin.
